### PR TITLE
Fix: Identification request kills homebridge

### DIFF
--- a/index.js
+++ b/index.js
@@ -482,7 +482,7 @@ ISYLightAccessory.prototype.identify = function(callback) {
 		this.device.sendLightCommand(false, function(result) {
 			callback();			
 		});		
-	});
+	}.bind(this));
 }
 
 // Handles request to set the current powerstate from homekit. Will ignore redundant commands. 
@@ -588,11 +588,7 @@ function ISYSceneAccessory(log,device) {
 
 // Handles the identify command
 ISYSceneAccessory.prototype.identify = function(callback) {
-	this.device.sendLightCommand(true, function(result) {
-		this.device.sendLightCommand(false, function(result) {
-			callback();
-		});
-	});
+  callback();
 }
 
 // Handles request to set the current powerstate from homekit. Will ignore redundant commands.


### PR DESCRIPTION
This change fixes the [issue](https://github.com/rodtoll/homebridge-isy-js/issues/37) I raised today, as well as an older [duplicate issue](https://github.com/rodtoll/homebridge-isy-js/issues/17) I missed.

In addition, I stripped down the identify method for scenes. I have ISY programs watching scenes to initiate more complex sequences, and quickly turning them on and off for identification didn't feel right for me.
